### PR TITLE
Feature/aws

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ This project is built on top of a number of different tools best suited for thei
   - Static HTML creation using partials and includes
   - Dynamic clientside templates for javascript
 
-## Deployments
-The project comes with a built in `deploy` task that will run a dist and pipe the files to s3 for a static site hosting. You can run `gulp deploy -e production` and it will run a production dist as well.
+## Deployment as a static site to s3
+The project comes with a built in `deploy-static-aws` task that will run a dist and pipe the files to s3 for a static site hosting. You can run `gulp deploy-static-aws -e production` and it will run a production dist as well.
 
 In order to use this make sure you have configured your `~/.aws/credentials` file for the user with the access key and secret, as well as the `gulp/config.js` with the identity to use, the bucket and the region.
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ The project comes with a built in `deploy-static-aws` task that will run a dist 
 
 In order to use this make sure you have configured your `~/.aws/credentials` file for the user with the access key and secret, as well as the `gulp/config.js` with the identity to use, the bucket and the region.
 
+## Deploy assets
+Sometimes you may want to just deploy assets to s3, this can be done with `gulp deploy-assets`. This will upload all assets to the s3 bucket specified in the config.js and do a replace on any references to those assets in html, css and js.
+
 ## Tasks
 run `gulp --tasks`
 <pre>

--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ This project is built on top of a number of different tools best suited for thei
   - Static HTML creation using partials and includes
   - Dynamic clientside templates for javascript
 
+## Deployments
+The project comes with a built in `deploy` task that will run a dist and pipe the files to s3 for a static site hosting. You can run `gulp deploy -e production` and it will run a production dist as well.
+
+In order to use this make sure you have configured your `~/.aws/credentials` file for the user with the access key and secret, as well as the `gulp/config.js` with the identity to use, the bucket and the region.
+
 ## Tasks
 run `gulp --tasks`
 <pre>

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -14,6 +14,13 @@ module.exports = {
     "browserlist": ["> 0.5%", "last 2 versions", "Firefox ESR", "Opera 12.1"]
   },
 
+  // AWS settings
+  "aws": {
+    "identity": "rip-it-with-gulp",
+    "bucket": "rip-it-with-gulp",
+    "region": "us-east-1"
+  },
+
   // Meta for frontend static templates
   "meta": {
     "google_analytics": "1234",

--- a/gulp/tasks/deploy-static-aws.js
+++ b/gulp/tasks/deploy-static-aws.js
@@ -52,11 +52,14 @@ function aws(done){
   // deploy
   generateManifest( config.dev)
   .then( () => {
-    parseDir( config.dev )
+    emptyBucket()
     .then( () => {
-      console.log("Site now live at: " + config.aws.bucket + ".s3.amazonaws.com");
-      done();
-    })
+      parseDir( config.dev )
+      .then( () => {
+        done();
+        console.log("Site now live at: " + config.aws.bucket + ".s3.amazonaws.com");
+      });
+    });
   });
 }
 
@@ -76,7 +79,6 @@ function emptyBucket(){
     // Clear Everything out
     s3.listObjects(params, (err, data) => {
       if (err) console.log(err);
-      console.log(data)
 
       params = {Bucket: config.aws.bucket};
       params.Delete = {Objects:[]};
@@ -87,7 +89,7 @@ function emptyBucket(){
 
       s3.deleteObjects(params, (err, data) => {
         console.log("Bucket emptied!");
-        resolve(data);
+        resolve();
       });
     });
   });

--- a/gulp/tasks/deploy-static-aws.js
+++ b/gulp/tasks/deploy-static-aws.js
@@ -1,12 +1,12 @@
 /*
-     _            _
-  __| | ___ _ __ | | ___  _   _
- / _` |/ _ \ '_ \| |/ _ \| | | |
-| (_| |  __/ |_) | | (_) | |_| |
- \__,_|\___| .__/|_|\___/ \__, |
+     _            _                   _        _   _
+  __| | ___ _ __ | | ___  _   _   ___| |_ __ _| |_(_) ___    __ ___      _____
+ / _` |/ _ \ '_ \| |/ _ \| | | | / __| __/ _` | __| |/ __|  / _` \ \ /\ / / __|
+| (_| |  __/ |_) | | (_) | |_| | \__ \ || (_| | |_| | (__  | (_| |\ V  V /\__ \
+ \__,_|\___| .__/|_|\___/ \__, | |___/\__\__,_|\__|_|\___|  \__,_| \_/\_/ |___/
            |_|            |___/
 
-Push up to s3!
+Push up to s3 as a static site
 
 Make sure you have your credentials stored locally in ~/.aws/credentials and have your identity added.
 
@@ -22,7 +22,7 @@ let gulp    = require("gulp"),
 ------------------------------------------
 | deploy:void (-)
 ------------------------------------------ */
-gulp.task("deploy", gulp.series("dist", aws));
+gulp.task("deploy-static-aws", gulp.series("dist", aws));
 
 /*
 ------------------------------------------
@@ -46,7 +46,7 @@ function aws(done){
   s3 = new AWS.S3();
   emptyBucket(function(){
     console.log("Clean Complete");
-    fillBucket();
+    parseDir( config.dev );
   });
   done();
 }
@@ -83,35 +83,6 @@ function emptyBucket(callback){
 
 /*
 ------------------------------------------
-| fillBucket:void (-)
-|
-| Upload files to the bucket.
-| Loop over all files in directory if a folder
-| Upload directly, if file upload to partent directory.
------------------------------------------- */
-function fillBucket(){
-  fs.readdir( config.dev, function(err, files) {
-    files.forEach( function(file) {
-      if( path.extname(file) != "" ){
-        upload(config.dev, config.dev + "/" + file);
-      } else {
-        var params = {
-          Bucket: config.aws.bucket,
-          Prefix: config.dev.replace(config.dev + "/", ""),
-          Key: "",
-          Body: "",
-          ACL: "public-read"
-        }
-        s3.putObject(params, function(){
-          parseDir( config.dev + "/" + file);
-        });
-      }
-    });
-  });
-}
-
-/*
-------------------------------------------
 | parseDir:void (-)
 |
 | Recursive function to go over files in directories.
@@ -129,9 +100,7 @@ function parseDir( dir ){
           Body: "",
           ACL: "public-read"
         }
-        s3.putObject(params, function(){
-          parseDir( dir + "/" + file);
-        });
+        parseDir( dir + "/" + file);
       }
     });
   });

--- a/gulp/tasks/deploy-static-aws.js
+++ b/gulp/tasks/deploy-static-aws.js
@@ -44,7 +44,7 @@ function aws(done){
 
   // S3
   s3 = new AWS.S3();
-  emptyBucket(function(){
+  emptyBucket( () => {
     console.log("Clean Complete");
     parseDir( config.dev );
   });
@@ -58,26 +58,24 @@ function aws(done){
 | Empty the bucket.
 ------------------------------------------ */
 function emptyBucket(callback){
-  var params = {
+  let params = {
     Bucket: config.aws.bucket,
     Prefix: ""
   };
 
   // Clear Everything out
-  s3.listObjects(params, function(err, data) {
+  s3.listObjects(params, (err, data) => {
     if (err) console.log(err);
     if (data.Contents.length == 0) callback();
 
     params = {Bucket: config.aws.bucket};
     params.Delete = {Objects:[]};
 
-    data.Contents.forEach(function(content) {
+    data.Contents.forEach( (content) => {
       params.Delete.Objects.push({Key: content.Key});
     });
 
-    s3.deleteObjects(params, function(err, data) {
-      callback();
-    });
+    s3.deleteObjects(params, (err, data) => { callback(); });
   });
 }
 
@@ -88,12 +86,12 @@ function emptyBucket(callback){
 | Recursive function to go over files in directories.
 ------------------------------------------ */
 function parseDir( dir ){
-  fs.readdir( dir, function(err, files) {
-    files.forEach( function(file) {
+  fs.readdir( dir, (err, files) => {
+    files.forEach( (file) => {
       if( path.extname(file) != "" ){
         upload(dir, dir + "/" + file);
       } else {
-        var params = {
+        let params = {
           Bucket: config.aws.bucket,
           Prefix: dir.replace(dir + "/", ""),
           Key: "",
@@ -113,7 +111,7 @@ function parseDir( dir ){
 | Upload files.
 ------------------------------------------ */
 function upload(dir, file ){
-  var params = {
+  let params = {
     Bucket: config.aws.bucket + dir.replace(config.dev, ""),
     Key: "",
     Body: "",
@@ -121,15 +119,13 @@ function upload(dir, file ){
     ContentType: mime.lookup(file)
   }
 
-  var fileStream = fs.createReadStream(file);
-  fileStream.on("error", function(err) {
-    console.log("File Error", err);
-  });
+  let fileStream = fs.createReadStream(file);
+  fileStream.on("error", (err) => { console.log("File Error", err); });
 
   file = file.replace(config.dev + "/", "");
   params.Body = fileStream;
   params.Key = path.basename(file);
-  s3.upload (params, function (err, data) {
+  s3.upload (params, (err, data) => {
     if (err) {
       console.log("Error", err);
     } if (data) {

--- a/gulp/tasks/deploy-static-aws.js
+++ b/gulp/tasks/deploy-static-aws.js
@@ -57,7 +57,7 @@ function aws(done){
       parseDir( config.dev )
       .then( () => {
         done();
-        console.log("Site now live at: " + config.aws.bucket + ".s3.amazonaws.com");
+        console.log("Site now live at: " + config.aws.bucket + ".s3-website-" + config.aws.region + ".amazonaws.com");
       });
     });
   });

--- a/gulp/tasks/deploy.js
+++ b/gulp/tasks/deploy.js
@@ -119,18 +119,18 @@ function fillBucket(){
 function parseDir( dir ){
   fs.readdir( dir, function(err, files) {
     files.forEach( function(file) {
-      if( path.extname(file) != '' ){
-        upload(dir, dir + '/' + file);
+      if( path.extname(file) != "" ){
+        upload(dir, dir + "/" + file);
       } else {
         var params = {
           Bucket: config.aws.bucket,
           Prefix: dir.replace(dir + "/", ""),
-          Key: '',
-          Body: '',
-          ACL: 'public-read'
+          Key: "",
+          Body: "",
+          ACL: "public-read"
         }
         s3.putObject(params, function(){
-          parseDir( dir + '/' + file);
+          parseDir( dir + "/" + file);
         });
       }
     });
@@ -146,15 +146,15 @@ function parseDir( dir ){
 function upload(dir, file ){
   var params = {
     Bucket: config.aws.bucket + dir.replace(config.dev, ""),
-    Key: '',
-    Body: '',
-    ACL: 'public-read',
+    Key: "",
+    Body: "",
+    ACL: "public-read",
     ContentType: mime.lookup(file)
   }
 
   var fileStream = fs.createReadStream(file);
-  fileStream.on('error', function(err) {
-    console.log('File Error', err);
+  fileStream.on("error", function(err) {
+    console.log("File Error", err);
   });
 
   file = file.replace(config.dev + "/", "");

--- a/gulp/tasks/deploy.js
+++ b/gulp/tasks/deploy.js
@@ -1,0 +1,170 @@
+/*
+     _            _
+  __| | ___ _ __ | | ___  _   _
+ / _` |/ _ \ '_ \| |/ _ \| | | |
+| (_| |  __/ |_) | | (_) | |_| |
+ \__,_|\___| .__/|_|\___/ \__, |
+           |_|            |___/
+
+Push up to s3!
+
+Make sure you have your credentials stored locally in ~/.aws/credentials and have your identity added.
+
+*/
+let gulp    = require("gulp"),
+    AWS     = require("aws-sdk"),
+    fs      = require("fs"),
+    path    = require("path"),
+    mime    = require("mime"),
+    config  = require("../config");
+
+/*
+------------------------------------------
+| deploy:void (-)
+------------------------------------------ */
+gulp.task("deploy", gulp.series("dist", aws));
+
+/*
+------------------------------------------
+| aws:stream (-)
+|
+| Deploy project to s3.
+------------------------------------------ */
+function aws(done){
+
+  // Set the identity
+  AWS.config.credentials = new AWS.SharedIniFileCredentials({
+    profile: config.aws.identity
+  });
+
+  // For dev purposes only
+  AWS.config.update({
+    region: config.aws.region
+  });
+
+  // S3
+  s3 = new AWS.S3();
+  emptyBucket(function(){
+    console.log("Clean Complete");
+    fillBucket();
+  });
+  done();
+}
+
+/*
+------------------------------------------
+| emptyBucket:void (-)
+|
+| Empty the bucket.
+------------------------------------------ */
+function emptyBucket(callback){
+  var params = {
+    Bucket: config.aws.bucket,
+    Prefix: ""
+  };
+
+  // Clear Everything out
+  s3.listObjects(params, function(err, data) {
+    if (err) console.log(err);
+    if (data.Contents.length == 0) callback();
+
+    params = {Bucket: config.aws.bucket};
+    params.Delete = {Objects:[]};
+
+    data.Contents.forEach(function(content) {
+      params.Delete.Objects.push({Key: content.Key});
+    });
+
+    s3.deleteObjects(params, function(err, data) {
+      callback();
+    });
+  });
+}
+
+/*
+------------------------------------------
+| fillBucket:void (-)
+|
+| Upload files to the bucket.
+| Loop over all files in directory if a folder
+| Upload directly, if file upload to partent directory.
+------------------------------------------ */
+function fillBucket(){
+  fs.readdir( config.dev, function(err, files) {
+    files.forEach( function(file) {
+      if( path.extname(file) != "" ){
+        upload(config.dev, config.dev + "/" + file);
+      } else {
+        var params = {
+          Bucket: config.aws.bucket,
+          Prefix: config.dev.replace(config.dev + "/", ""),
+          Key: "",
+          Body: "",
+          ACL: "public-read"
+        }
+        s3.putObject(params, function(){
+          parseDir( config.dev + "/" + file);
+        });
+      }
+    });
+  });
+}
+
+/*
+------------------------------------------
+| parseDir:void (-)
+|
+| Recursive function to go over files in directories.
+------------------------------------------ */
+function parseDir( dir ){
+  fs.readdir( dir, function(err, files) {
+    files.forEach( function(file) {
+      if( path.extname(file) != '' ){
+        upload(dir, dir + '/' + file);
+      } else {
+        var params = {
+          Bucket: config.aws.bucket,
+          Prefix: dir.replace(dir + "/", ""),
+          Key: '',
+          Body: '',
+          ACL: 'public-read'
+        }
+        s3.putObject(params, function(){
+          parseDir( dir + '/' + file);
+        });
+      }
+    });
+  });
+}
+
+/*
+------------------------------------------
+| upload:void (-)
+|
+| Upload files.
+------------------------------------------ */
+function upload(dir, file ){
+  var params = {
+    Bucket: config.aws.bucket + dir.replace(config.dev, ""),
+    Key: '',
+    Body: '',
+    ACL: 'public-read',
+    ContentType: mime.lookup(file)
+  }
+
+  var fileStream = fs.createReadStream(file);
+  fileStream.on('error', function(err) {
+    console.log('File Error', err);
+  });
+
+  file = file.replace(config.dev + "/", "");
+  params.Body = fileStream;
+  params.Key = path.basename(file);
+  s3.upload (params, function (err, data) {
+    if (err) {
+      console.log("Error", err);
+    } if (data) {
+      console.log("Upload Success", data.Location);
+    }
+  });
+}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "mustache": "^2.3.0"
   },
   "devDependencies": {
+    "aws-sdk": "^2.125.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.0.1",


### PR DESCRIPTION
This runs a dist then a deploy to s3 and uses `~/.aws/credentials` for the key and secret.

Thinking it might also be cool to have another task for just assets such as `gulp deploy-assets -e production` would run a rev on assets upload to s3 bucket and then do a replace through styles, scripts and markup.